### PR TITLE
feat: add native scheduler implementation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,11 +2,17 @@ package main
 
 import (
 	"net/http"
+	"time"
 
+	"github.com/rcliao/scheduler"
 	"github.com/rcliao/scheduler/web"
+	"github.com/rcliao/scheduler/worker"
 )
 
 func main() {
+	schedulerInstance := worker.NewNativeScheduler()
+	duration, _ := time.ParseDuration("10s")
+	schedulerInstance.DelayJob(duration, "test", scheduler.DebugFunc)
 	http.HandleFunc("/hello", web.HelloHandler())
 	http.ListenAndServe(":9000", nil)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/rcliao/scheduler
 
 go 1.12
+
+require github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
+github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/processor/debug.go
+++ b/processor/debug.go
@@ -1,0 +1,13 @@
+package processor
+
+import "fmt"
+
+// ProcessFunc defines the func type for process func
+type ProcessFunc func()
+
+// Debug func prints the data into console
+func Debug(data string) ProcessFunc {
+	return func() {
+		fmt.Printf("DEBUG func got data: %s", data)
+	}
+}

--- a/scheduler.go
+++ b/scheduler.go
@@ -13,24 +13,37 @@ const (
 	WebHook
 )
 
+// JobStatus enum defines all possible job status values
+type JobStatus int
+
+const (
+	// Scheduled meaning that the job status is pending to be completed in the future
+	Scheduled JobStatus = iota
+	// Cancelled means the job is cancelled and will not complete any time in future
+	Cancelled
+	// Completed means that the scheduler confirms the job is completed
+	Completed
+)
+
 // Job is the base entity to store the scheduling meta data as well as its work
 type Job struct {
 	ID                 string
 	ScheduledTimestamp time.Time
-	Status             string
+	Status             JobStatus
 	Type               JobType
 	Data               string
 }
 
 // JobRepository manages the database interaction to store and retrieve job data
 type JobRepository interface {
-	GetJob(ID string) (Job, error)
-	PutJob(ID string, job Job) (Job, error)
+	Create(job Job) (Job, error)
+	Get(ID string) (Job, error)
+	Put(ID string, job Job) (Job, error)
 }
 
 // Scheduler is the top level API to schedule a delay job
 type Scheduler interface {
-	DelayJob(duration time.Duration, jobType JobType, data string) (Job, error)
-	Reschedule(ID string, duration time.Duration) (Job, error)
+	DelayJob(duration time.Duration, data string, jobType JobType) (Job, error)
+	Reschedule(ID string, duration time.Duration) error
 	Cancel(ID string) error
 }

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// HelloHandler renders the hello world!
 func HelloHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hello, World!")

--- a/worker/native.go
+++ b/worker/native.go
@@ -1,0 +1,70 @@
+package worker
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rcliao/scheduler"
+	"github.com/rcliao/scheduler/processor"
+)
+
+/**
+ * worker package defines all possible implementation of the scheduler. First
+ * implementation is to implement using Go's built-in time.AfterFunc
+ */
+
+// NativeScheduler utilizes the Go's built-in method `time.AfterFunc` to
+// schedule delayed jobs in future
+type NativeScheduler struct {
+	timerMap map[string]*time.Timer
+}
+
+// NewNativeScheduler is constructor for creating a new NativeScheduler with empty timerMap
+func NewNativeScheduler() NativeScheduler {
+	return NativeScheduler{
+		timerMap: make(map[string]*time.Timer),
+	}
+}
+
+// DelayJob creates a future event for the job and will be processed at the duration time
+func (s *NativeScheduler) DelayJob(duration time.Duration, data string, jobType scheduler.JobType) (scheduler.Job, error) {
+	// TODO: create a factory method caller to use different processor func
+	timer := time.AfterFunc(duration, processor.Debug(data))
+	id := uuid.New().String()
+	job := scheduler.Job{
+		ID:                 id,
+		ScheduledTimestamp: time.Now().Add(duration),
+		Status:             scheduler.Scheduled,
+		Type:               jobType,
+		Data:               data,
+	}
+	s.timerMap[id] = timer
+	return job, nil
+}
+
+// Reschedule allows the consumer to update the delay job delayed time
+func (s *NativeScheduler) Reschedule(ID string, duration time.Duration) error {
+	timer, ok := s.timerMap[ID]
+	if !ok {
+		return errors.New("Cannot find job with id " + ID)
+	}
+	// when scheduled job has not been stopped
+	if !timer.Stop() {
+		<-timer.C
+	}
+	timer.Reset(duration)
+	return nil
+}
+
+// Cancel allows the consumer to cancel a job so that it will not happen in the future
+func (s *NativeScheduler) Cancel(ID string) error {
+	timer, ok := s.timerMap[ID]
+	if !ok {
+		return errors.New("Cannot find job with id " + ID)
+	}
+	if !timer.Stop() {
+		<-timer.C
+	}
+	return nil
+}


### PR DESCRIPTION
# Context

This PR adds the first implementation of the scheduler using Go’s built-in function (time.AfterFunc - https://golang.org/pkg/time/#AfterFunc)